### PR TITLE
Get logic analyzer sofware in shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,11 @@
           src = fetchGit { url = "https://github.com/ninjasource/elf2uf2-rs"; ref = "pico2-support"; rev = "5813dd0b54dde3aed93822e196f67715a2de8c5d"; };
         };
 
+        sdcc = pkgs.sdcc.overrideAttrs {
+          outputs = ["out" "doc"] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ "man" ];
+        };
+        
+
         toolchain = with fenix.packages.${system};
           combine [
             stable.rustc
@@ -32,6 +37,7 @@
 
         shell = pkgs.mkShell {
           buildInputs = with pkgs; [
+            sdcc
             toolchain
             probe-rs-tools
             elf2uf2-rs

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         };
 
         sdcc = pkgs.sdcc.overrideAttrs {
-          outputs = ["out" "doc"] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ "man" ];
+          outputs = ["out" "doc"] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ "man" ];
         };
         
 

--- a/flake.nix
+++ b/flake.nix
@@ -11,16 +11,17 @@
   outputs = { self, nixpkgs, fenix, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system: 
       let
-        pkgs = import nixpkgs { inherit system; };
+        fixSdcc = final: prev: {
+          sdcc = prev.sdcc.overrideAttrs {
+            outputs = ["out" "doc"] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ "man" ];
+          };
+        };
+        
+        pkgs = import nixpkgs { inherit system; overlays = [fixSdcc];};
 
         elf2uf2-rs = pkgs.elf2uf2-rs.overrideAttrs {
           src = fetchGit { url = "https://github.com/ninjasource/elf2uf2-rs"; ref = "pico2-support"; rev = "5813dd0b54dde3aed93822e196f67715a2de8c5d"; };
         };
-
-        sdcc = pkgs.sdcc.overrideAttrs {
-          outputs = ["out" "doc"] ++ pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [ "man" ];
-        };
-        
 
         toolchain = with fenix.packages.${system};
           combine [
@@ -37,7 +38,7 @@
 
         shell = pkgs.mkShell {
           buildInputs = with pkgs; [
-            sdcc
+            pulseview
             toolchain
             probe-rs-tools
             elf2uf2-rs


### PR DESCRIPTION
Adds pulseview, a logic analyzer frontend as a debugging tool available in our devshell.
